### PR TITLE
Speed up high precision path with optional gmpy backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,14 @@ Reiterating this equation `Max_Iter` times will give an approximation of ![pi/2]
 This program will store the value of your ![pi](http://mathurl.com/6cu2u8.png) approximation in a .txt file called `pi.txt`. To change the precision of the value stored, you can change the variable `Precision` in the PiApprox.m.
 
 Try playing around with the variables `x` and `Exponent` to see which values arrive to the approximation quicker.
+
+## Python port performance
+
+The Python script mirrors the MATLAB loop but relies on pure-Python arbitrary
+precision arithmetic by default. That makes the million-digit run
+significantly slower than MATLAB's symbolic toolbox, which calls into the
+compiled GMP/MPFR libraries. Installing [`gmpy2`](https://pypi.org/project/gmpy2/)
+lets `mpmath` switch to those libraries and the script automatically uses that
+faster backend when it is present. If even that is not enough, the remaining
+option is to implement the loop in C or C++ directly on top of GMP/MPFR so the
+entire computation stays in compiled code.

--- a/pi_approx.py
+++ b/pi_approx.py
@@ -1,0 +1,67 @@
+"""Python port of the ``PiApprox.m`` script.
+
+The MATLAB code:
+
+* Starts with ``x = 1.01``.
+* Iteratively applies ``x = x^((Exponent)^(cos(x)))`` for ``Max_Iter`` updates.
+* Doubles the final ``x`` and prints it with ``Precision`` digits using ``vpa``.
+* Writes the high-precision value into ``pi.txt`` via ``diary``.
+
+This module mirrors that behaviour using :mod:`mpmath` so that we can request
+over one million digits of precision for the final result, as required.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from mpmath import mp
+
+try:  # ``set_backend`` is only present in newer mpmath releases.
+    from mpmath.libmp import set_backend
+except ImportError:  # pragma: no cover - gracefully handle older versions
+    set_backend = None
+else:  # pragma: no cover - exercise when the helper exists
+    try:  # pragma: no cover - ``gmpy2`` accelerates multiprecision arithmetic
+        import gmpy2  # type: ignore
+    except ImportError:
+        pass
+    else:
+        set_backend("gmpy")
+
+
+@dataclass(frozen=True)
+class PiApproxConfig:
+    """Configuration matching the constants used in ``PiApprox.m``."""
+
+    initial_value: mp.mpf = mp.mpf("1.01")
+    exponent: int = 2
+    iterations: int = 1000
+    precision_digits: int = 1_000_000
+    guard_digits: int = 50
+    output_path: Path = Path("pi.txt")
+
+
+def approximate_pi(config: PiApproxConfig) -> None:
+    """Run the iterative approximation and persist the high-precision result."""
+
+    # ``PiApprox.m`` relies on MATLAB's variable-precision arithmetic to carry
+    # millions of digits when ``digits(Precision)`` is invoked.  We mirror that
+    # behaviour by running the entire iterative phase with the full requested
+    # precision so the accumulated value retains all available digits.
+    mp.dps = config.precision_digits + config.guard_digits
+    x = mp.mpf(config.initial_value)
+    base = mp.mpf(config.exponent)
+
+    for _ in range(config.iterations):
+        cos_x = mp.cos(x)
+        x = mp.power(x, mp.power(base, cos_x))
+
+    result = mp.nstr(2 * x, n=config.precision_digits, strip_zeros=False)
+
+    config.output_path.write_text(result, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    approximate_pi(PiApproxConfig())


### PR DESCRIPTION
## Summary
- enable mpmath to switch to the gmpy-powered backend when available to accelerate the million-digit loop
- reuse precomputed multiprecision operands inside the iterative update to trim overhead
- document why the Python port runs slower than MATLAB and how to reach comparable speeds with gmpy2 or native code

## Testing
- not run (mpmath dependency is unavailable in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69098291127483308eb4607e143fbc10)